### PR TITLE
Add asset manager token breakdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@balancednetwork/balanced-js": "1.2.34",
+    "@balancednetwork/balanced-js": "1.2.35",
     "@balancednetwork/sdk-core": "1.0.1",
     "@material-ui/core": "4.12.3",
     "@material-ui/lab": "4.0.0-alpha.60",

--- a/src/components/AssetManagerTokenBreakdown/index.tsx
+++ b/src/components/AssetManagerTokenBreakdown/index.tsx
@@ -1,0 +1,51 @@
+import QuestionHelper, { QuestionWrapper } from 'components/QuestionHelper';
+import { HIGH_PRICE_ASSET_DP } from 'constants/tokens';
+import { AssetManagerToken } from 'queries/assetManager';
+import React from 'react';
+import { Box } from 'rebass';
+import styled from 'styled-components';
+
+const Grid = styled(Box)`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 6px;
+  column-gap: 5px;
+`;
+
+const NetworkName = styled(Box)`
+  ${({ theme }) => `color: ${theme.colors.text1};`};
+`;
+
+const Amount = styled(Box)`
+  text-align: right;
+`;
+
+const AssetManagerTokenBreakdown = ({
+  breakdown,
+  spacing = { x: 0, y: 0 },
+}: {
+  breakdown: AssetManagerToken[];
+  spacing?: { x: number; y: number };
+}) => {
+  return (
+    <QuestionWrapper style={{ marginLeft: `${spacing.x}px`, transform: `translateY(${spacing.y}px)` }}>
+      <QuestionHelper
+        text={
+          <Grid>
+            {breakdown.map(assetManagerToken => (
+              <>
+                <NetworkName>{assetManagerToken.networkName}:</NetworkName>
+                <Amount>{`${assetManagerToken.tokenAmount.toFixed(
+                  HIGH_PRICE_ASSET_DP[assetManagerToken.tokenAmount.currency.address] || 0,
+                  { groupFormatting: ',' },
+                )} ${assetManagerToken.tokenAmount.currency.symbol}`}</Amount>
+              </>
+            ))}
+          </Grid>
+        }
+      />
+    </QuestionWrapper>
+  );
+};
+
+export default AssetManagerTokenBreakdown;

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -232,6 +232,22 @@ export const ETH = new Token(
   'Ethereum',
 );
 
+export const BNB = new Token(SupportedChainId.MAINNET, 'cx2d552c485ec8bcaa75aac02424e2aca6ffdb2f1b', 18, 'BNB', 'BNB');
+export const AVAX = new Token(
+  SupportedChainId.MAINNET,
+  'cx66a031cc3bd305c76371fb586e93801b948254f0',
+  18,
+  'AVAX',
+  'Avalanche',
+);
+export const INJ = new Token(
+  SupportedChainId.MAINNET,
+  'cx4297f4b63262507623b6ad575d0d8dd2db980e4e',
+  18,
+  'INJ',
+  'Injective',
+);
+
 // todo: calculate supported tokens from supported tokens info
 export const SUPPORTED_TOKENS: { [chainId: number]: Token[] } = {
   [SupportedChainId.MAINNET]: [
@@ -252,6 +268,9 @@ export const SUPPORTED_TOKENS: { [chainId: number]: Token[] } = {
     hyTB,
     BTCB,
     ETH,
+    BNB,
+    INJ,
+    AVAX,
   ],
   [SupportedChainId.YEOUIDO]: [
     ICX_YEOUIDO,

--- a/src/pages/PerformanceDetails/sections/StabilityFundSection/index.tsx
+++ b/src/pages/PerformanceDetails/sections/StabilityFundSection/index.tsx
@@ -18,6 +18,8 @@ import { StyledSkeleton } from '../EarningSection';
 import { Change, DatePickerInput } from '../HoldingsSection';
 
 import 'react-datepicker/dist/react-datepicker.css';
+import { useAssetManagerTokens } from 'queries/assetManager';
+import AssetManagerTokenBreakdown from 'components/AssetManagerTokenBreakdown';
 
 const BalanceGrid = styled.div`
   display: grid;
@@ -81,6 +83,7 @@ const GridItemHeader = styled(GridItem)`
 const StabilityFundSection = () => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date(new Date().setDate(new Date().getDate() - 1)));
   const { data: fundLimits } = useFundLimits();
+  const { data: assetManagerTokensBreakdown } = useAssetManagerTokens();
 
   let totalCurrent = 0;
   let totalPast = 0;
@@ -138,6 +141,7 @@ const StabilityFundSection = () => {
         {holdingsCurrent &&
           Object.keys(holdingsCurrent).map(contract => {
             const token = holdingsCurrent[contract].currency.wrapped;
+            const tokenBreakdown = assetManagerTokensBreakdown && assetManagerTokensBreakdown[contract];
             const fundLimit = fundLimits && fundLimits[token.address];
             const curAmount = new BigNumber(holdingsCurrent[contract].toFixed());
             const prevAmount =
@@ -166,7 +170,12 @@ const StabilityFundSection = () => {
                   <Flex alignItems="center">
                     <CurrencyLogo currency={token as Currency} size="40px" />
                     <Box ml={2}>
-                      <Text color="text">{token.name}</Text>
+                      <Flex>
+                        <Text color="text">{token.name}</Text>
+                        {tokenBreakdown && tokenBreakdown.length > 1 && (
+                          <AssetManagerTokenBreakdown breakdown={tokenBreakdown} spacing={{ x: 5, y: 0 }} />
+                        )}
+                      </Flex>
                       <Text color="text" opacity={0.75}>
                         {token.symbol}
                       </Text>

--- a/src/sections/TokenSection.tsx
+++ b/src/sections/TokenSection.tsx
@@ -18,6 +18,8 @@ import useTimestampRounded from 'hooks/useTimestampRounded';
 import { LoaderComponent } from 'pages/PerformanceDetails/utils';
 import { Typography } from 'theme';
 import { formatPriceChange, getFormattedNumber } from 'utils/formatter';
+import { useAssetManagerTokens } from 'queries/assetManager';
+import AssetManagerTokenBreakdown from 'components/AssetManagerTokenBreakdown';
 
 export const COMPACT_ITEM_COUNT = 8;
 
@@ -208,6 +210,8 @@ const TokenItem = ({ token, isLast }: TokenItemProps) => {
   const start = Math.floor(tsStart / 1000);
   const end = Math.floor(tsEnd / 1000);
   const { data: trendData } = useTokenTrendData(token.symbol, start, end);
+  const { data: assetManagerTokensBreakdown } = useAssetManagerTokens();
+  const tokenBreakdown = assetManagerTokensBreakdown && assetManagerTokensBreakdown[token.address];
 
   return (
     <>
@@ -218,7 +222,12 @@ const TokenItem = ({ token, isLast }: TokenItemProps) => {
               <CurrencyLogoFromURI address={token.address} size="40px" />
             </Box>
             <Box ml={2} sx={{ minWidth: '160px' }}>
-              <Text>{token.name.replace(' TOKEN', ' Token')}</Text>
+              <Flex>
+                <Text>{token.name.replace(' TOKEN', ' Token')}</Text>
+                {tokenBreakdown && tokenBreakdown.length > 1 && (
+                  <AssetManagerTokenBreakdown breakdown={tokenBreakdown} spacing={{ x: 5, y: 0 }} />
+                )}
+              </Flex>
               <Text color="text1">{token.symbol}</Text>
             </Box>
           </Flex>

--- a/src/sections/WithdrawalLimits/StabilityFundLimits/index.tsx
+++ b/src/sections/WithdrawalLimits/StabilityFundLimits/index.tsx
@@ -9,6 +9,8 @@ import { Typography } from 'theme';
 import { getFormattedNumber } from 'utils/formatter';
 import { DashGrid, DataText, MinWidthContainer } from '../CollateralLimits';
 import { Token } from '@balancednetwork/sdk-core';
+import { useAssetManagerTokens } from 'queries/assetManager';
+import AssetManagerTokenBreakdown from 'components/AssetManagerTokenBreakdown';
 
 export const SkeletonTokenPlaceholder = () => {
   return (
@@ -51,6 +53,7 @@ export const SkeletonTokenPlaceholder = () => {
 
 const StabilityFundLimits = () => {
   const { data: withdrawalsFloorData } = useWithdrawalsFloorStabilityFundData();
+  const { data: assetManagerTokensBreakdown } = useAssetManagerTokens();
 
   return (
     <Box overflow="auto">
@@ -67,6 +70,7 @@ const StabilityFundLimits = () => {
               const isLast = index === withdrawalsFloorData.assetFloorData.length - 1;
               const dp = HIGH_PRICE_ASSET_DP[asset.token.address] || 0;
               const availableRatio = asset.current.minus(asset.floor).div(asset.current);
+              const tokenBreakdown = assetManagerTokensBreakdown && assetManagerTokensBreakdown[asset.token.address];
 
               return (
                 <Fragment key={index}>
@@ -80,7 +84,12 @@ const StabilityFundLimits = () => {
                           />
                         </Box>
                         <Box ml={2} sx={{ minWidth: '160px' }}>
-                          <Typography fontSize={16}>{asset.token.name.replace(' TOKEN', ' Token')}</Typography>
+                          <Flex>
+                            <Typography fontSize={16}>{asset.token.name.replace(' TOKEN', ' Token')}</Typography>
+                            {tokenBreakdown && tokenBreakdown.length > 1 && (
+                              <AssetManagerTokenBreakdown breakdown={tokenBreakdown} spacing={{ x: 5, y: 0 }} />
+                            )}
+                          </Flex>
                           <Typography color="text1" fontSize={16}>
                             {asset.token.symbol}
                           </Typography>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,10 +1173,10 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
-"@balancednetwork/balanced-js@1.2.34":
-  version "1.2.34"
-  resolved "https://registry.yarnpkg.com/@balancednetwork/balanced-js/-/balanced-js-1.2.34.tgz#dcb6872a67c2cf777547f2023b0e464ab5e7e434"
-  integrity sha512-tqErVlAaG9oaVdlNumMCU3Z6S2DHQU6OjD+Oz6CiNJF0gd/8e7HUqXOIxmUE5LdWKXqEllhfsRJODl1JP4AhdA==
+"@balancednetwork/balanced-js@1.2.35":
+  version "1.2.35"
+  resolved "https://registry.yarnpkg.com/@balancednetwork/balanced-js/-/balanced-js-1.2.35.tgz#8fefd0a54b16ea3f8f505a499fa727c354adc86f"
+  integrity sha512-2Wwa7wqHvCItj3gz11f6TCN9v+JiR+lV+oFFWBFgvxuU6gOiLiLqlyUorwk3Y2eKutmdm58eB6/Ofk+xVg0lDw==
   dependencies:
     "@balancednetwork/hw-app-icx" "^1.0.6"
     bignumber.js "9.0.1"


### PR DESCRIPTION
close #210

for reference
https://github.com/balancednetwork/balanced-network-interface/issues/1328#issuecomment-2091854471

@parrot9design do we want to show the _breakdown_ for the cross chain tokens that have only one chain compatible to be explicitly clear it's a cross chain token?
<img width="600" alt="image" src="https://github.com/balancednetwork/balanced-network-info/assets/13098459/f8086fe1-3ed7-41b8-81eb-1776e5b7907e">
